### PR TITLE
Adding a safe inset for iPhone X on primary nav.

### DIFF
--- a/src/_includes/css/landmarks/_primary_nav.css
+++ b/src/_includes/css/landmarks/_primary_nav.css
@@ -38,7 +38,7 @@ nav[aria-label='Primary links'] {
   .nav--primary__link {
     color: var(--color-white);
     display: block;
-    padding: 0.5rem;
+    padding: 0.5rem 0.5rem calc(0.5rem + env(safe-area-inset-bottom));
     text-decoration: none;
 
     &:hover {


### PR DESCRIPTION
Took cues from the MDN article here ( https://developer.mozilla.org/en-US/docs/Web/CSS/env() ) to ensure my global navigation had proper lower padding in iPhone X screen size. Closes #25 