### PR TITLE
Adding a skip to content link for keyboard a11y

### DIFF
--- a/src/_includes/css/components/_skipNav.css
+++ b/src/_includes/css/components/_skipNav.css
@@ -1,0 +1,16 @@
+.content__skip-nav {
+  display: flex;
+  font-variation-settings: "wght" var(--font-weight-semi-bold);
+  padding: 1.25rem 3rem;
+  position: absolute;
+  top: -9999px;
+
+  &:focus {
+    background-color: var(--color-white);
+    top: 0;
+  }
+
+  &:focus-visible {
+    outline-offset: 0;
+  }
+}

--- a/src/_includes/css/main.css
+++ b/src/_includes/css/main.css
@@ -13,4 +13,5 @@
 @import 'landmarks/_pagination_nav.css';
 @import 'layouts/_services.css';
 @import 'layouts/_posts.css';
+@import 'components/_skipNav.css';
 @import 'components/_actionLinks.css';

--- a/src/_includes/layouts/layout.njk
+++ b/src/_includes/layouts/layout.njk
@@ -12,6 +12,7 @@
     {% include "layouts/partials/_head.njk" %}
   </head>
   <body>
+    {% include "layouts/partials/_skipNav.njk" %}
     <div class="grid__rows">
       {% include "layouts/partials/_header.njk" %} {% include
       "layouts/partials/_primarynav.njk" %}

--- a/src/_includes/layouts/partials/_footer.njk
+++ b/src/_includes/layouts/partials/_footer.njk
@@ -1,4 +1,4 @@
-<footer role="contentinfo">
+<footer aria-label="Shout outs and social media" role="contentinfo">
   <div class="footer__block">
     <h2 class="footer__heading">Shout outs</h2>
     <div class="footer__column">

--- a/src/_includes/layouts/partials/_header.njk
+++ b/src/_includes/layouts/partials/_header.njk
@@ -1,4 +1,4 @@
-<header role="banner">
+<header aria-label="Continuum Design. Work for the digital age." role="banner">
   <div class="content__layout">
     <a href="/">
       <span>continuum design</span>

--- a/src/_includes/layouts/partials/_skipNav.njk
+++ b/src/_includes/layouts/partials/_skipNav.njk
@@ -1,0 +1,1 @@
+<a class="content__skip-nav" href="#content">Skip to content</a>

--- a/src/_includes/layouts/postLayout.njk
+++ b/src/_includes/layouts/postLayout.njk
@@ -11,6 +11,7 @@
     {% include "layouts/partials/_head.njk" %}
   </head>
   <body>
+    {% include "layouts/partials/_skipNav.njk" %}
     <div class="grid__rows grid__rows--five layout--has-breadcrumb layout--has-aside layout--posts">
       {% include "layouts/partials/_header.njk" %}
       {% include "layouts/partials/_primarynav.njk" %}

--- a/src/_includes/layouts/servicesLayout.njk
+++ b/src/_includes/layouts/servicesLayout.njk
@@ -12,6 +12,7 @@
     {% include "layouts/partials/_head.njk" %}
   </head>
   <body>
+    {% include "layouts/partials/_skipNav.njk" %}
     <div class="grid__rows grid__rows--five layout--has-breadcrumb">
       {% include "layouts/partials/_header.njk" %}
       {% include "layouts/partials/_primarynav.njk" %}

--- a/src/contact/contact.njk
+++ b/src/contact/contact.njk
@@ -3,9 +3,9 @@ title: Contact me for your next project
 layout: layouts/layout.njk
 ---
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
 
     <blockquote class="content__lead-paragraph">
       <p>

--- a/src/index.njk
+++ b/src/index.njk
@@ -3,9 +3,9 @@ title: Continuum Design.
 layout: layouts/layout.njk
 ---
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
 
     <p>Hi, I&lsquo;m Trevor. This is my studio, Continuum Design. I'm glad you're here.</p>
 

--- a/src/posts/blog-post.njk
+++ b/src/posts/blog-post.njk
@@ -5,9 +5,9 @@ parentDir: '/posts/'
 parentText: All posts
 ---
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
     <p>This is the first paragraph of the first post!</p>
   </div>
 </main>

--- a/src/posts/posts.njk
+++ b/src/posts/posts.njk
@@ -4,9 +4,9 @@ layout: layouts/layout.njk
 eleventyExcludeFromCollections: true
 ---
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
 
     <p>
       This is the posts page. We should list the posts in reverse chronological

--- a/src/posts/second-awesome-post.njk
+++ b/src/posts/second-awesome-post.njk
@@ -8,9 +8,9 @@ tags: ['posts', 'security', 'networking']
 ---
 
 <div class="posts__grid">
-  <main aria-labelledby="post-title-id" role="main">
+  <main aria-labelledby="content-heading" role="main" id="content">
     <div class="content__layout">
-      <h1 id="post-title-id">{{ title }}</h1>
+      <h1 id="content-heading">{{ title }}</h1>
 
       <div class="posts__lead">
         <blockquote class="posts__lead-paragraph">

--- a/src/services/accessibility.njk
+++ b/src/services/accessibility.njk
@@ -11,9 +11,9 @@ title: Accessible by design
 {% set previousPost = collections.services | getPreviousCollectionItem(page) %}
 {% set nextPost = collections.services | getNextCollectionItem(page) %}
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
 
     <div class="services__opening">
       <blockquote class="services__lead-paragraph">

--- a/src/services/brand-and-identity.njk
+++ b/src/services/brand-and-identity.njk
@@ -11,9 +11,9 @@ title: A memorable brand will set your business apart
 {% set previousPost = collections.services | getPreviousCollectionItem(page) %}
 {% set nextPost = collections.services | getNextCollectionItem(page) %}
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
     <div class="services__opening">
       <blockquote class="services__lead-paragraph">
         <p>

--- a/src/services/services.njk
+++ b/src/services/services.njk
@@ -4,9 +4,9 @@ layout: layouts/layout.njk
 eleventyExcludeFromCollections: true;
 ---
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
     <div class="services__opening">
       <blockquote class="services__lead-paragraph">
         <p>

--- a/src/services/visual-design.njk
+++ b/src/services/visual-design.njk
@@ -11,9 +11,9 @@ title: It all starts with visual design
 {% set previousPost = collections.services | getPreviousCollectionItem(page) %}
 {% set nextPost = collections.services | getNextCollectionItem(page) %}
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
 <div class="content__layout">
-  <h1>{{ title }}</h1>
+  <h1 id="content-heading">{{ title }}</h1>
   <div class="services__opening">
     <blockquote class="services__lead-paragraph">
       <p>

--- a/src/services/web-development.njk
+++ b/src/services/web-development.njk
@@ -11,9 +11,9 @@ title: Web development is art. And science.
 {% set previousPost = collections.services | getPreviousCollectionItem(page) %}
 {% set nextPost = collections.services | getNextCollectionItem(page) %}
 
-<main role="main">
+<main aria-labelledby="content-heading" role="main" id="content">
   <div class="content__layout">
-    <h1>{{ title }}</h1>
+    <h1 id="content-heading">{{ title }}</h1>
 
     <div class="services__opening">
       <blockquote class="services__lead-paragraph">


### PR DESCRIPTION
Closes #33

* Adding CSS for major Mac browsers.
* Tested in Chrome, Firefox, Safari
* Safari doesn't handle focus-visible by default, so I broke that into it's own rule here.
* Flexbox works really well to center single elements!