### PR TITLE
Adding inline script to switch media from print to all.

### DIFF
--- a/src/_includes/layouts/partials/_head.njk
+++ b/src/_includes/layouts/partials/_head.njk
@@ -1,7 +1,16 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
 <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;700;800;900&display=swap" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;700;800;900&display=swap" media="print" onload="this.media='all'" />
+<link rel="stylesheet" data-async="css-async-load" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;700;800;900&display=swap" media="print" />
 <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Literata:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap" media="print" onload="this.media='all'" />
+<link rel="stylesheet" data-async="css-async-load" href="https://fonts.googleapis.com/css2?family=Literata:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap" media="print" />
+<!-- TODO: Add a CSP with hash in prod -->
+<script type="text/javascript">
+  Array.prototype.slice.call(document.querySelectorAll('[data-async="css-async-load"]')).map(function(e) {
+    e.addEventListener('load', function() {
+      this.media = "all";
+      this.onload = null;
+    });
+  });
+</script>
 <link rel="stylesheet" href="/css/main.css" />
 <link rel="author" href="/.well-known/humans.txt" />


### PR DESCRIPTION
Removing the inline `this.media="all"` on the CSS declarations, adding a `script` tag instead. This will let me use a proper CSP that adds a SHA-256 hash as an option to run inline scripts safely.

Closes #36 