### PR TITLE
Make banner image use `picture`, `source` and `srcset` for better performance.

### DIFF
--- a/src/_includes/css/components/_skipNav.css
+++ b/src/_includes/css/components/_skipNav.css
@@ -8,6 +8,7 @@
   &:focus {
     background-color: var(--color-white);
     top: 0;
+    z-index: var(--z-index-5);
   }
 
   &:focus-visible {

--- a/src/_includes/css/global/_images.css
+++ b/src/_includes/css/global/_images.css
@@ -1,0 +1,7 @@
+img,
+embed,
+object,
+source,
+video {
+  max-width: 100%;
+}

--- a/src/_includes/css/global/_images.css
+++ b/src/_includes/css/global/_images.css
@@ -1,7 +1,6 @@
 img,
 embed,
 object,
-source,
 video {
   max-width: 100%;
 }

--- a/src/_includes/css/landmarks/_header.css
+++ b/src/_includes/css/landmarks/_header.css
@@ -4,6 +4,7 @@
 [role='banner'] {
   background-color: var(--color-background-dusty-rose);
   height: 6.25rem;
+  position: relative;
 
   a {
     display: inline-block;
@@ -33,6 +34,26 @@
       font-size: var(--fluid-0);
       margin: 0;
       padding-right: 1rem;
+    }
+  }
+
+  .content__layout--header-text {
+    position: relative;
+    z-index: var(--z-index-2);
+  }
+
+  .content__layout--hero {
+    background-color: var(--color-background-dusty-rose);
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: var(--z-index-1);
+
+    picture,
+    img {
+      height: 100%;
     }
   }
 
@@ -67,14 +88,14 @@
    * https://css-tricks.com/snippets/css/retina-display-media-query/
    * Phones and non-tablet devices
    */
-  @media only screen and (min-width: 20rem) {
+  /* @media only screen and (min-width: 20rem) {
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/mobile-header.jpg') top left/cover
       no-repeat;
-  }
+  } */
   
   /* High-density phones and non-tablet devices */
-  @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 20rem),
+  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 20rem),
     only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 20rem),
     only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 20rem),
     only screen and (min-device-pixel-ratio: 2) and (min-width: 20rem),
@@ -83,17 +104,17 @@
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/mobile-header@2x.jpg') top left/cover
       no-repeat;
-  }
+  } */
 
   /* Tablets */
-  @media only screen and (min-width: 48rem) {
+  /* @media only screen and (min-width: 48rem) {
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/tablet-header.jpg') top left/cover
       no-repeat;
-  }
+  } */
 
   /* High-density tablets */
-  @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 48rem),
+  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 48rem),
     only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 48rem),
     only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 48rem),
     only screen and (min-device-pixel-ratio: 2) and (min-width: 48rem),
@@ -102,17 +123,17 @@
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/tablet-header@2x.jpg') top left/cover
       no-repeat;
-  }
+  } */
 
   /* Mid-size screens 1024 to 1280px */
-  @media only screen and (min-width: 64rem) {
+  /* @media only screen and (min-width: 64rem) {
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/mid-header.jpg') top left/cover
       no-repeat;
-  }
+  } */
 
   /* Mid-size high-density screens 1024 to 1280px */
-  @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 64rem),
+  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 64rem),
     only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 64rem),
     only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 64rem),
     only screen and (min-device-pixel-ratio: 2) and (min-width: 64rem),
@@ -120,17 +141,17 @@
     only screen and (min-resolution: 2dppx) and (min-width: 64rem) {
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/mid-header@2x.jpg') top left/cover no-repeat;
-  }
+  } */
 
   /* Large screens 1280px and wider */
-  @media only screen and (min-width: 80rem) {
+  /* @media only screen and (min-width: 80rem) {
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/large-header.jpg') top left/cover
       no-repeat;
-  }
+  } */
 
   /* Large high-density screens 1280px and wider */
-  @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 80rem),
+  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 80rem),
     only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 80rem),
     only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 80rem),
     only screen and (min-device-pixel-ratio: 2) and (min-width: 80rem),
@@ -139,5 +160,5 @@
     background: var(--color-background-dusty-rose)
       url('../../images/backgrounds/large-header@2x.jpg') top left/cover
       no-repeat;
-  }
+  } */
 }

--- a/src/_includes/css/landmarks/_header.css
+++ b/src/_includes/css/landmarks/_header.css
@@ -37,6 +37,11 @@
     }
   }
 
+  img {
+    height: 6.25rem;
+    width: 100%;
+  }
+
   .content__layout--header-text {
     position: relative;
     z-index: var(--z-index-2);
@@ -50,11 +55,6 @@
     right: 0;
     top: 0;
     z-index: var(--z-index-1);
-
-    picture,
-    img {
-      height: 100%;
-    }
   }
 
   /* Tablet devices - 768px breakpoint */
@@ -68,11 +68,19 @@
         font-size: var(--fluid-1);
       }
     }
+
+    img {
+      height: 10rem;
+    }
   }
 
   /* Mid-size screens 1024px to 1280px */
   @media only screen and (min-width: 64rem) {
     height: 12rem;
+
+    img {
+      height: 12rem;
+    }
   }
 
   /* Large screens 1280px and wider */
@@ -82,83 +90,9 @@
     a {
       margin-top: 3rem;
     }
+
+    img {
+      height: 18rem;
+    }
   }
-
-  /*
-   * https://css-tricks.com/snippets/css/retina-display-media-query/
-   * Phones and non-tablet devices
-   */
-  /* @media only screen and (min-width: 20rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/mobile-header.jpg') top left/cover
-      no-repeat;
-  } */
-  
-  /* High-density phones and non-tablet devices */
-  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 20rem),
-    only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 20rem),
-    only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 20rem),
-    only screen and (min-device-pixel-ratio: 2) and (min-width: 20rem),
-    only screen and (min-resolution: 192dpi) and (min-width: 20rem),
-    only screen and (min-resolution: 2dppx) and (min-width: 20rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/mobile-header@2x.jpg') top left/cover
-      no-repeat;
-  } */
-
-  /* Tablets */
-  /* @media only screen and (min-width: 48rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/tablet-header.jpg') top left/cover
-      no-repeat;
-  } */
-
-  /* High-density tablets */
-  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 48rem),
-    only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 48rem),
-    only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 48rem),
-    only screen and (min-device-pixel-ratio: 2) and (min-width: 48rem),
-    only screen and (min-resolution: 192dpi) and (min-width: 48rem),
-    only screen and (min-resolution: 2dppx) and (min-width: 48rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/tablet-header@2x.jpg') top left/cover
-      no-repeat;
-  } */
-
-  /* Mid-size screens 1024 to 1280px */
-  /* @media only screen and (min-width: 64rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/mid-header.jpg') top left/cover
-      no-repeat;
-  } */
-
-  /* Mid-size high-density screens 1024 to 1280px */
-  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 64rem),
-    only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 64rem),
-    only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 64rem),
-    only screen and (min-device-pixel-ratio: 2) and (min-width: 64rem),
-    only screen and (min-resolution: 192dpi) and (min-width: 64rem),
-    only screen and (min-resolution: 2dppx) and (min-width: 64rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/mid-header@2x.jpg') top left/cover no-repeat;
-  } */
-
-  /* Large screens 1280px and wider */
-  /* @media only screen and (min-width: 80rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/large-header.jpg') top left/cover
-      no-repeat;
-  } */
-
-  /* Large high-density screens 1280px and wider */
-  /* @media only screen and (-webkit-min-device-pixel-ratio: 2) and (min-width: 80rem),
-    only screen and (min--moz-device-pixel-ratio: 2) and (min-width: 80rem),
-    only screen and (-o-min-device-pixel-ratio: 2/1) and (min-width: 80rem),
-    only screen and (min-device-pixel-ratio: 2) and (min-width: 80rem),
-    only screen and (min-resolution: 192dpi) and (min-width: 80rem),
-    only screen and (min-resolution: 2dppx) and (min-width: 80rem) {
-    background: var(--color-background-dusty-rose)
-      url('../../images/backgrounds/large-header@2x.jpg') top left/cover
-      no-repeat;
-  } */
 }

--- a/src/_includes/css/main.css
+++ b/src/_includes/css/main.css
@@ -1,6 +1,7 @@
 @import 'global/_variables.css';
 @import 'global/_utilities.css';
 @import 'global/_normalize.css';
+@import 'global/_images.css';
 @import 'global/_grid.css';
 @import 'global/_typography.css';
 @import 'global/_forms.css';

--- a/src/_includes/layouts/partials/_header.njk
+++ b/src/_includes/layouts/partials/_header.njk
@@ -1,5 +1,26 @@
 <header aria-label="Continuum Design. Work for the digital age." role="banner">
-  <div class="content__layout">
+  <div class="content__layout--hero">
+    <picture>
+      <source
+        media="(min-width: 80rem)"
+        srcset="../../images/backgrounds/large-header.jpg, ../../images/backgrounds/large-header@2x.jpg 2x"
+      />
+      <source
+        media="(min-width: 64rem)"
+        srcset="../../images/backgrounds/mid-header.jpg, ../../images/backgrounds/mid-header@2x.jpg 2x"
+      />
+      <source
+        media="(min-width: 48rem)"
+        srcset="../../images/backgrounds/tablet-header.jpg, ../../images/backgrounds/tablet-header@2x.jpg 2x"
+      />
+      <source
+        media="(min-width: 20rem)"
+        srcset="../../images/backgrounds/mobile-header.jpg, ../../images/backgrounds/mobile-header@2x.jpg 2x"
+      />
+      <img src="../../images/backgrounds/mobile-header.jpg" loading="lazy" alt="" />
+    </picture>
+  </div>
+  <div class="content__layout content__layout--header-text">
     <a href="/">
       <span>continuum design</span>
       <span>work. for the digital age.</span>

--- a/src/_includes/layouts/partials/_header.njk
+++ b/src/_includes/layouts/partials/_header.njk
@@ -17,7 +17,7 @@
         media="(min-width: 20rem)"
         srcset="../../images/backgrounds/mobile-header.jpg, ../../images/backgrounds/mobile-header@2x.jpg 2x"
       />
-      <img src="../../images/backgrounds/mobile-header.jpg" loading="lazy" alt="" />
+      <img src="../../images/backgrounds/mobile-header.jpg" alt="" />
     </picture>
   </div>
   <div class="content__layout content__layout--header-text">

--- a/src/_templates/postcss.11ty.js
+++ b/src/_templates/postcss.11ty.js
@@ -3,7 +3,6 @@ const path = require('path');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
 const postcssNested = require('postcss-nested');
-const cleanCSS = require("clean-css");
 const csso = require('postcss-csso');
 
 const generateCssHash = require('../_lib/generateCssHash');


### PR DESCRIPTION
This PR was done to move the hero banner out of the `<header` tag as a CSS background, and make use of current art direction stack of picture, source, and srcset. I used the article ["Responsive images"](https://web.dev/responsive-images/) from Google's Web.dev site.

PR closes #77 