### PR TITLE
Adding no index for .dev pages to _headers.

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,4 +1,10 @@
 # ========================================
+# Prevent .dev pages from being indexed
+# ========================================
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+# ========================================
 # .well-known directory
 # ========================================
 /.well-known


### PR DESCRIPTION
Adding a small snippet to the `_headers` file to prevent `*.pages.dev` being indexed. See https://developers.cloudflare.com/pages/platform/headers/#prevent-your-pagesdev-deployments-showing-in-search-results