### PR TITLE
[BUG] Improving contact form UX for screen readers on error.

### DIFF
--- a/src/_includes/css/global/_forms.css
+++ b/src/_includes/css/global/_forms.css
@@ -196,11 +196,7 @@ input:invalid {
       padding: 0.875rem 1.5rem;
     }
 
-    &:not(:focus) {
-      opacity: 0.5;
-      /* TODO: Ensure these transitions wouldn't be better as transforms */
-      transition: opacity 1s ease;
-    }
+    
   }
 }
 

--- a/src/_includes/css/global/_typography.css
+++ b/src/_includes/css/global/_typography.css
@@ -155,6 +155,16 @@ div[tabindex="-1"] {
   }
 }
 
+button:-moz-focusring,
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring {
+  &:focus-visible {
+    outline: 4px solid var(--color-background-dusty-rose--dark);
+    outline-offset: 6px;
+  }
+}
+
 a {
   color: var(--color-background-blue--dark);
 

--- a/src/_includes/js/contactForm.js
+++ b/src/_includes/js/contactForm.js
@@ -27,9 +27,12 @@ const createSubmitErrorMessage = (target) => {
     invalidInputs.length === 1 ? "" : "s"
   }. Please update and press the Send message button.`;
 
-  while (alertBox.firstChild) {
+  if (alertBox.firstChild) {
     alertBox.removeChild(alertBox.firstChild);
   }
+
+  alertBox.setAttribute("role", "alert");
+  alertBox.setAttribute("tabindex", "-1");
 
   alertTextNode.append(alertTextMsg);
   alertBox.append(alertTextNode);

--- a/src/_includes/js/contactForm.js
+++ b/src/_includes/js/contactForm.js
@@ -6,6 +6,7 @@ const contactForm = document.querySelector("form#continuum-contact-form");
 const fields = Array.prototype.slice.call(
   document.querySelectorAll(".js--validate")
 );
+const alertBox = document.querySelector(ALERT_BOX);
 
 const createInputErrorMessage = (field) => {
   const parent = field.closest("li");
@@ -17,11 +18,10 @@ const createInputErrorMessage = (field) => {
   field.setAttribute("aria-describedby", `error-msg-${fieldId}`);
 };
 
-const createSubmitErrorMessage = (target) => {
+const createSubmitErrorMessage = () => {
   const invalidInputs = document.querySelectorAll(
     ":scope .contact-form__fieldset :invalid"
   );
-  const alertBox = document.querySelector(target);
   const alertTextNode = document.createElement("p");
   const alertTextMsg = `Your form has ${invalidInputs.length} error${
     invalidInputs.length === 1 ? "" : "s"
@@ -36,9 +36,15 @@ const createSubmitErrorMessage = (target) => {
 
   alertTextNode.append(alertTextMsg);
   alertBox.append(alertTextNode);
+
   requestAnimationFrame(() => {
     alertBox.focus();
   });
+};
+
+const removeAlertboxAttributes = () => {
+  alertBox.removeAttribute("role");
+  alertBox.removeAttribute("tabindex");
 };
 
 const removeInputErrorMessage = (field) => {
@@ -83,7 +89,7 @@ const validateInputs = (e) => {
   if (!contactForm.checkValidity()) {
     e.preventDefault();
     e.stopImmediatePropagation();
-    createSubmitErrorMessage(ALERT_BOX);
+    createSubmitErrorMessage();
     return;
   }
 
@@ -101,5 +107,9 @@ document.addEventListener("DOMContentLoaded", () => {
     field.addEventListener("blur", (e) => removeInputErrorMessage(e.target));
   });
 
+  // Remove role and tabindex from alertbox
+  alertBox.addEventListener("blur", removeAlertboxAttributes);
+
+  // Validate inputs and make async fetch call
   contactForm.addEventListener("submit", validateInputs);
 });

--- a/src/contact/contact.njk
+++ b/src/contact/contact.njk
@@ -1,5 +1,5 @@
 ---
-title: Contact me for your next project
+title: Contact Continuum Design
 layout: layouts/layout.njk
 tags: ['sitemap']
 ---
@@ -28,11 +28,11 @@ tags: ['sitemap']
         <legend class="contact-form__legend">
           <h2>Your information</h2>
         </legend>
-        <div class="contact-form__alert" role="alert" tabindex="-1"></div>
+        <div class="contact-form__alert"></div>
         <ul class="utils__list--no-bullets contact-form__list" role="list">
           <li class="contact-form__list-item">
             <label for="name" class="contact-form__label"><span aria-hidden="true" class="contact-form--flourish">&#8674;&nbsp;</span>Your name</label>
-            <p aria-live="assertive" class="contact-form__error-msg" id="error-msg-name">A name of two or more letters is required</p>
+            <p class="contact-form__error-msg" id="error-msg-name">A name of two or more letters is required</p>
             <input
               autocomplete="name"
               class="js--validate"
@@ -49,7 +49,7 @@ tags: ['sitemap']
             <label for="email" class="contact-form__label"
               ><span aria-hidden="true" class="contact-form--flourish">&#8674;&nbsp;</span>Email address</label
             >
-            <p aria-live="assertive" class="contact-form__error-msg" id="error-msg-email">A valid email address is required</p>
+            <p class="contact-form__error-msg" id="error-msg-email">A valid email address is required</p>
             <input
               autocomplete="email"
               class="js--validate"
@@ -64,7 +64,7 @@ tags: ['sitemap']
             <label for="telephone" class="contact-form__label"
               ><span aria-hidden="true" class="contact-form--flourish">&#8674;&nbsp;</span>Telephone number <em>(optional)</em></label
             >
-             <p aria-live="assertive" class="contact-form__error-msg" id="error-msg-telephone">Enter a valid telephone number with area code</p>
+             <p class="contact-form__error-msg" id="error-msg-telephone">Enter a valid telephone number with area code</p>
             <input
               autocomplete="tel"
               class="js--validate"
@@ -78,7 +78,7 @@ tags: ['sitemap']
           </li>
           <li class="contact-form__list-item">
             <label for="message" class="contact-form__label"><span aria-hidden="true" class="contact-form--flourish">&#8674;&nbsp;</span>Your message to Continuum Design</label>
-            <p aria-live="assertive" class="contact-form__error-msg" id="error-msg-message">A short message is required</p>
+            <p class="contact-form__error-msg" id="error-msg-message">A short message is required</p>
             <textarea
               class="js--validate"
               id="message"
@@ -93,7 +93,7 @@ tags: ['sitemap']
               <input class="js--validate" type="checkbox" id="optedIn" name="optedIn" required />
               <span>I give Continuum Design permission to contact me</span>
             </label>
-            <p aria-live="assertive" class="contact-form__error-msg" id="error-msg-consented">You must check the consent box before submitting</p>
+            <p class="contact-form__error-msg" id="error-msg-consented">You must check the consent box before submitting</p>
           </li>
           <li class="contact-form__list-item utils__display--none">
             <label for="ztob" class="contact-form__label">Leave this field blank if you are a human</label>


### PR DESCRIPTION
The contact form had too many live regions and screen readers were not reading out the general error message correctly. I removed the live regions from individual errors and refactored the general message container to apply (and remove) `role` and `tabindex` as needed.

PR closes #162 